### PR TITLE
대화하자 멘션과 통화하자 멘션 외에도 적응팀 멘션은 바로 검열되지 않게 하되, 대화하자 및 통화하자처럼 여러번 멘션 시 테러로 간주하고 타임아웃하도록 코드 수정 (마늘 서버 전용 기능) #170

### DIFF
--- a/main.py
+++ b/main.py
@@ -224,7 +224,7 @@ get_all_xp_setting()
 # 서버별 초대코드 캐시
 invite_cache = {}
 
-do_mention_role = [1378253467940028498, 1375687128708677682, 1378256091070074900, 1400872501378158764]
+do_mention_role = [1378253467940028498, 1375687128708677682, 1378256091070074900, 1400872501378158764, 1416704481382502470]
 
 mention_timestamps = defaultdict(list)
 
@@ -1850,7 +1850,7 @@ async def on_message(message):
         if automod_setting['mention'][0] :
             if message.channel.id != 1320304882393153586: 
                 if message.guild.id == using_server : 
-                    if "<@&1400872501378158764>" in message.content or "<@&1375687128708677682>" in message.content or "<@&1378253467940028498>" in message.content or "<@&1378256091070074900>" in message.content : 
+                    if "<@&1416704481382502470>" in message.content or "<@&1400872501378158764>" in message.content or "<@&1375687128708677682>" in message.content or "<@&1378253467940028498>" in message.content or "<@&1378256091070074900>" in message.content : 
                         return
                 for i in automod_keyword6 :
                     if i in message.content :


### PR DESCRIPTION
대화하자 멘션과 통화하자 멘션 외에도 적응팀 멘션은 바로 검열되지 않게 하되, 대화하자 및 통화하자처럼 여러번 멘션 시 테러로 간주하고 타임아웃하도록 코드 수정 (마늘 서버 전용 기능) #170