### PR TITLE
/제재내역확인 페이지 이동할 때 페이지 번호를 입력하는 것도 가능하게 하고 #282 /제재내역확인 페이지 이전/다음 버튼을 명령어를 사용한 사람 외에도 누를 수 있는 버그도 수정 #283

### DIFF
--- a/main.py
+++ b/main.py
@@ -702,7 +702,7 @@ class ModerationLogView(discord.ui.View):
             super().__init__()
             self.parent_view = parent_view
         
-            pagenum = discord.ui.TextInput(label="이동할 페이지 번호", placeholder="이동할 페이지 번호", required=True)
+            pagenum = discord.ui.TextInput(custom_id = "pagenum", label="이동할 페이지 번호", placeholder="이동할 페이지 번호", required=True)
             pagenum = self.add_item(pagenum)
 
         async def on_submit(self, interaction: discord.Interaction):

--- a/main.py
+++ b/main.py
@@ -703,11 +703,11 @@ class ModerationLogView(discord.ui.View):
             self.parent_view = parent_view
         
             pagenum = discord.ui.TextInput(label="이동할 페이지 번호", placeholder="이동할 페이지 번호", required=True)
-            self.add_item(pagenum)
+            pagenum = self.add_item(pagenum)
 
         async def on_submit(self, interaction: discord.Interaction):
             try : 
-                pagenum_value = int(self.children.pagenum.value)
+                pagenum_value = int(self.pagenum.value)
             except ValueError : 
                 await interaction.response.send_message(f"유효하지 않은 페이지 번호 값입니다. 숫자를 입력해 주세요.")
                 return

--- a/main.py
+++ b/main.py
@@ -620,11 +620,12 @@ def print_time(x):
     return " ".join(parts)
 
 class ModerationLogView(discord.ui.View):
-    def __init__(self, entries, user, page=0):
+    def __init__(self, entries, user, interact_user, page=0):
         super().__init__()
         self.entries = entries
         self.user = user
         self.page = page
+        self.interact_user = interact_user
 
     @property
     def max_pages(self):
@@ -668,6 +669,9 @@ class ModerationLogView(discord.ui.View):
 
     @discord.ui.button(label="이전", style=discord.ButtonStyle.gray, disabled=True)
     async def previous(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.interact_user.id : 
+            await interaction.response.send_message("자기 자신이 실행한 명령어 출력 결과의 버튼만 사용이 가능합니다.", ephemeral = False)
+            return
         self.page -= 1
         if self.page == 0:
             button.disabled = True
@@ -676,12 +680,42 @@ class ModerationLogView(discord.ui.View):
 
     @discord.ui.button(label="다음", style=discord.ButtonStyle.gray)
     async def next(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.interact_user.id : 
+            await interaction.response.send_message("자기 자신이 실행한 명령어 출력 결과의 버튼만 사용이 가능합니다.", ephemeral = False)
+            return
         self.page += 1
         if self.page >= self.max_pages - 1:
             button.disabled = True
         self.children[0].disabled = False
         await interaction.response.edit_message(embed=self.get_embed(), view=self)
+    
+    @discord.ui.button(label="페이지 번호 입력", style=discord.ButtonStyle.primary)
+    async def select_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.interact_user.id : 
+            await interaction.response.send_message("자기 자신이 실행한 명령어 출력 결과의 버튼만 사용이 가능합니다.", ephemeral = False)
+            return
+        modal = self.PageInputModal(self)
+        await interaction.response.send_modal(modal)
 
+    class PageInputModal(discord.ui.Modal, title="페이지 번호로 이동"):
+        def __init__(self, parent_view):
+            super().__init__()
+            self.parent_view = parent_view
+        
+            pagenum = discord.ui.TextInput(label="이동할 페이지 번호", placeholder="이동할 페이지 번호", required=True)
+            self.add_item(self.pagenum)
+
+        async def on_submit(self, interaction: discord.Interaction):
+            try : 
+                pagenum_value = int(self.pagenum.value)
+            except ValueError : 
+                await interaction.response.send_message(f"유효하지 않은 페이지 번호 값입니다. 숫자를 입력해 주세요.")
+                return
+            if pagenum_value > self.parent_view.max_pages or self.pagenum.value < 1:
+                await interaction.response.send_message(f"유효하지 않은 페이지 번호 값입니다. 1 이상 {self.parent_view.max_pages} 이하의 값을 입력해 주세요.")
+                return
+            self.parent_view.page = pagenum_value
+            await interaction.response.edit_message(embed=self.parent_view.get_embed(), view=self.parent_view)
 
 '''
 # 이메일 전송 함수
@@ -6965,7 +6999,7 @@ async def check_moderation_log(interaction: discord.Interaction, 사용자: disc
     
     conn.close()
 
-    view = ModerationLogView(records, 사용자)
+    view = ModerationLogView(records, 사용자, interaction.user)
     await interaction.followup.send(embed=view.get_embed(), view=view)
 
 def split_text(text, chunk_size=3000):

--- a/main.py
+++ b/main.py
@@ -670,7 +670,7 @@ class ModerationLogView(discord.ui.View):
     @discord.ui.button(label="이전", style=discord.ButtonStyle.gray, disabled=True)
     async def previous(self, interaction: discord.Interaction, button: discord.ui.Button):
         if interaction.user.id != self.interact_user.id : 
-            await interaction.response.send_message("자기 자신이 실행한 명령어 출력 결과의 버튼만 사용이 가능합니다.", ephemeral = False)
+            await interaction.response.send_message("자기 자신이 실행한 명령어 출력 결과의 버튼만 사용이 가능합니다.", ephemeral = True)
             return
         self.page -= 1
         if self.page == 0:
@@ -681,7 +681,7 @@ class ModerationLogView(discord.ui.View):
     @discord.ui.button(label="다음", style=discord.ButtonStyle.gray)
     async def next(self, interaction: discord.Interaction, button: discord.ui.Button):
         if interaction.user.id != self.interact_user.id : 
-            await interaction.response.send_message("자기 자신이 실행한 명령어 출력 결과의 버튼만 사용이 가능합니다.", ephemeral = False)
+            await interaction.response.send_message("자기 자신이 실행한 명령어 출력 결과의 버튼만 사용이 가능합니다.", ephemeral = True)
             return
         self.page += 1
         if self.page >= self.max_pages - 1:
@@ -692,7 +692,7 @@ class ModerationLogView(discord.ui.View):
     @discord.ui.button(label="페이지 번호 입력", style=discord.ButtonStyle.primary)
     async def select_page(self, interaction: discord.Interaction, button: discord.ui.Button):
         if interaction.user.id != self.interact_user.id : 
-            await interaction.response.send_message("자기 자신이 실행한 명령어 출력 결과의 버튼만 사용이 가능합니다.", ephemeral = False)
+            await interaction.response.send_message("자기 자신이 실행한 명령어 출력 결과의 버튼만 사용이 가능합니다.", ephemeral = True)
             return
         modal = self.PageInputModal(self)
         await interaction.response.send_modal(modal)
@@ -702,19 +702,19 @@ class ModerationLogView(discord.ui.View):
             super().__init__()
             self.parent_view = parent_view
         
-            pagenum = discord.ui.TextInput(custom_id = "pagenum", label="이동할 페이지 번호", placeholder="이동할 페이지 번호", required=True)
-            pagenum = self.add_item(pagenum)
+            pagenum = discord.ui.TextInput(label="이동할 페이지 번호", placeholder="이동할 페이지 번호", required=True)
+            self.pagenum = self.add_item(pagenum)
 
         async def on_submit(self, interaction: discord.Interaction):
             try : 
-                pagenum_value = int(self.pagenum.value)
+                pagenum_value = int(self.children[0].value)
             except ValueError : 
-                await interaction.response.send_message(f"유효하지 않은 페이지 번호 값입니다. 숫자를 입력해 주세요.")
+                await interaction.response.send_message(f"유효하지 않은 페이지 번호 값입니다. 숫자를 입력해 주세요.", ephemeral = True)
                 return
-            if pagenum_value > self.parent_view.max_pages or self.pagenum.value < 1:
-                await interaction.response.send_message(f"유효하지 않은 페이지 번호 값입니다. 1 이상 {self.parent_view.max_pages} 이하의 값을 입력해 주세요.")
+            if pagenum_value > self.parent_view.max_pages or pagenum_value < 1:
+                await interaction.response.send_message(f"유효하지 않은 페이지 번호 값입니다. 1 이상 {self.parent_view.max_pages} 이하의 값을 입력해 주세요.", ephemeral = True)
                 return
-            self.parent_view.page = pagenum_value
+            self.parent_view.page = pagenum_value - 1
             await interaction.response.edit_message(embed=self.parent_view.get_embed(), view=self.parent_view)
 
 '''

--- a/main.py
+++ b/main.py
@@ -707,7 +707,7 @@ class ModerationLogView(discord.ui.View):
 
         async def on_submit(self, interaction: discord.Interaction):
             try : 
-                pagenum_value = int(self.pagenum.value)
+                pagenum_value = int(self.children.pagenum.value)
             except ValueError : 
                 await interaction.response.send_message(f"유효하지 않은 페이지 번호 값입니다. 숫자를 입력해 주세요.")
                 return

--- a/main.py
+++ b/main.py
@@ -703,7 +703,7 @@ class ModerationLogView(discord.ui.View):
             self.parent_view = parent_view
         
             pagenum = discord.ui.TextInput(label="이동할 페이지 번호", placeholder="이동할 페이지 번호", required=True)
-            self.add_item(self.pagenum)
+            self.add_item(pagenum)
 
         async def on_submit(self, interaction: discord.Interaction):
             try : 


### PR DESCRIPTION
테스트가 완료된 코드입니다. 이론상 프로덕션 환경에서도 정상 작동합니다.